### PR TITLE
Drop OCaml < 4.08 & use Stdlib everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         ocaml-compiler:
-          - 4.04.x
-          - 4.05.x
-          - 4.06.x
-          - 4.07.x
           - 4.08.x
           - 4.09.x
           - 4.10.x

--- a/dune-project
+++ b/dune-project
@@ -15,5 +15,6 @@
  (name ppx_monad)
  (synopsis "A Syntax Extension for all Monadic Syntaxes")
  (depends
+  (ocaml (>= 4.08.0))
    dune-configurator
   (ppxlib (>= 0.9.0))))

--- a/ppx_monad.opam
+++ b/ppx_monad.opam
@@ -9,6 +9,7 @@ homepage: "https://github.com/Niols/ppx_monad"
 bug-reports: "https://github.com/Niols/ppx_monad/issues"
 depends: [
   "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
   "dune-configurator"
   "ppxlib" {>= "0.9.0"}
   "odoc" {with-doc}

--- a/src/ppx/list/ppx_monad_ppx_list.ml
+++ b/src/ppx/list/ppx_monad_ppx_list.ml
@@ -6,13 +6,14 @@ let mk_return ~loc x =
 let mk_bind ~loc e f =
   let (pcmap, cmap) = Ppx_monad_lib.fresh_variable () in
   let (pbind, bind) = Ppx_monad_lib.fresh_variable () in
+  (* re-implement concat_map, only in Stdlib.List since 4.10.0 *)
   [%expr
     let [%p pcmap] = fun f l ->
       let rec aux f acc = function
-        | [] -> List.rev acc
+        | [] -> Stdlib.List.rev acc
         | x :: l ->
           let xs = f x in
-          aux f (List.rev_append xs acc) l
+          aux f (Stdlib.List.rev_append xs acc) l
       in aux f [] l
     in
     let [%p pbind] = fun e f -> [%e cmap] f e in

--- a/src/ppx/option/ppx_monad_ppx_option.ml
+++ b/src/ppx/option/ppx_monad_ppx_option.ml
@@ -1,24 +1,24 @@
 open Ppxlib
 
 let mk_return ~loc x =
-  [%expr Some [%e x]]
+  [%expr Stdlib.Option.Some [%e x]]
 
 let mk_bind ~loc e f =
   let (px, x) = Ppx_monad_lib.fresh_variable () in
   [%expr
     match [%e e] with
-    | Some [%p px] -> [%e f] [%e x]
-    | None -> None]
+    | Stdlib.Option.Some [%p px] -> [%e f] [%e x]
+    | Stdlib.Option.None -> Stdlib.Option.None]
 
 let mk_fail ~loc e =
-  [%expr let () = [%e e] in None]
+  [%expr let () = [%e e] in Stdlib.Option.None]
 
 let mk_catch ~loc e f =
   let (px, x) = Ppx_monad_lib.fresh_variable () in
   [%expr
     match [%e e] with
-    | Some [%p px] -> Some [%e x]
-    | None -> [%e f] ()]
+    | Stdlib.Option.Some [%p px] -> Stdlib.Option.Some [%e x]
+    | Stdlib.Option.None -> [%e f] ()]
 
 let () = Ppx_monad_lib.register "option"
     ~applies_on:"opt(ion)?"

--- a/src/ppx/option/ppx_monad_ppx_option.ml
+++ b/src/ppx/option/ppx_monad_ppx_option.ml
@@ -4,11 +4,7 @@ let mk_return ~loc x =
   [%expr Stdlib.Option.Some [%e x]]
 
 let mk_bind ~loc e f =
-  let (px, x) = Ppx_monad_lib.fresh_variable () in
-  [%expr
-    match [%e e] with
-    | Stdlib.Option.Some [%p px] -> [%e f] [%e x]
-    | Stdlib.Option.None -> Stdlib.Option.None]
+  [%expr Stdlib.Option.bind [%e e] [%e f]]
 
 let mk_fail ~loc e =
   [%expr let () = [%e e] in Stdlib.Option.None]

--- a/src/ppx/result/ppx_monad_ppx_result.ml
+++ b/src/ppx/result/ppx_monad_ppx_result.ml
@@ -1,26 +1,26 @@
 open Ppxlib
 
 let mk_return ~loc x =
-  [%expr Ok [%e x]]
+  [%expr Stdlib.Result.Ok [%e x]]
 
 let mk_bind ~loc e f =
   let (px, x) = Ppx_monad_lib.fresh_variable () in
   let (py, y) = Ppx_monad_lib.fresh_variable () in
   [%expr
     match [%e e] with
-    | Ok [%p px] -> [%e f] [%e x]
-    | Error [%p py] -> Error [%e y]]
+    | Stdlib.Result.Ok [%p px] -> [%e f] [%e x]
+    | Stdlib.Result.Error [%p py] -> Stdlib.Result.Error [%e y]]
 
 let mk_fail ~loc y =
-  [%expr Error [%e y]]
+  [%expr Stdlib.Result.Error [%e y]]
 
 let mk_catch ~loc e f =
   let (px, x) = Ppx_monad_lib.fresh_variable () in
   let (py, y) = Ppx_monad_lib.fresh_variable () in
   [%expr
     match [%e e] with
-    | Ok [%p px] -> Ok [%e x]
-    | Error [%p py] -> [%e f] [%e y]]
+    | Stdlib.Result.Ok [%p px] -> Stdlib.Result.Ok [%e x]
+    | Stdlib.Result.Error [%p py] -> [%e f] [%e y]]
 
 let () = Ppx_monad_lib.register "result.ok"
     ~applies_on:"ok|res(ult)?(.ok)?"

--- a/src/ppx/result/ppx_monad_ppx_result.ml
+++ b/src/ppx/result/ppx_monad_ppx_result.ml
@@ -4,12 +4,7 @@ let mk_return ~loc x =
   [%expr Stdlib.Result.Ok [%e x]]
 
 let mk_bind ~loc e f =
-  let (px, x) = Ppx_monad_lib.fresh_variable () in
-  let (py, y) = Ppx_monad_lib.fresh_variable () in
-  [%expr
-    match [%e e] with
-    | Stdlib.Result.Ok [%p px] -> [%e f] [%e x]
-    | Stdlib.Result.Error [%p py] -> Stdlib.Result.Error [%e y]]
+  [%expr Stdlib.Result.bind [%e e] [%e f]]
 
 let mk_fail ~loc y =
   [%expr Stdlib.Result.Error [%e y]]

--- a/src/ppx/seq/ppx_monad_ppx_seq.ml
+++ b/src/ppx/seq/ppx_monad_ppx_seq.ml
@@ -1,10 +1,10 @@
 open Ppxlib
 
 let mk_return ~loc x =
-  [%expr Seq.return [%e x]]
+  [%expr Stlib.Seq.return [%e x]]
 
 let mk_bind ~loc e f =
-  [%expr Seq.flat_map [%e f] [%e e]]
+  [%expr Stdlib.Seq.flat_map [%e f] [%e e]]
 
 let () = Ppx_monad_lib.register "seq"
     ~mk_return ~mk_bind


### PR DESCRIPTION
It is causing troubles because of the change of name of the standard library, from `Stdlib` to `Pervasives`. Since even Debian stable now has OCaml 4.11, I feel it is reasonable to drop support for OCaml below 4.08. We can come back from this if it turns out to be a problem for some users some day.